### PR TITLE
Fix schema Map Usage in build-data-view

### DIFF
--- a/src/cljs/hap_browser/core.cljs
+++ b/src/cljs/hap_browser/core.cljs
@@ -81,7 +81,7 @@
   (let [schema (get-in doc [:embedded :profile :data :schema])]
     (reduce-kv
       (fn [r k v]
-        (let [schema (or (schema k) (schema (s/optional-key k)))]
+        (let [schema (or (get schema k) (get schema (s/optional-key k)))]
           (conj r (assoc-when {:key k :value v :raw-value (raw-value v)}
                               :type schema))))
       []


### PR DESCRIPTION
When using a map like a function, the compiled javascript call() fails if the used map is nil.
